### PR TITLE
Solving ValueError caused by broken/incomplete csv data files

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -48,8 +48,22 @@ def load_csv_data(file_path):
         with open(file_path) as f:
             reader = csv.reader(f)
             return np.array([row for row in reader], dtype=np.float32)
+
     except FileNotFoundError:
         logging.error(f"Error: {file_path} not found.")
+
+    except ValueError:
+        with open(file_path) as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+    
+        max_cols = max(len(row) for row in rows)
+        if len(rows[-1]) < max_cols:    #eliminating the broken last row
+            rows.pop()
+        return np.array(rows, dtype=np.float32)
+
+        logging.error(f"Error: {file_path} csv file is found but broken.")
+        logging.info("The last row of the data with imperfect column numbers were eliminated")
 
 
 def generate_metrics(

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: aind-fip-qc-raw
+name: aind-fip-qc-raw_forPR_kh
 description: Basic structure of a capsule to be customized as needed.
 authors:
 - name: AIND


### PR DESCRIPTION
I updated `load_csv_data` function to handle incomplete csv files with different length.
1. upon ValueError, the new function pop the last row out.
2. logging error/info while making the rest of QC generation works.

No dedicated QC metrics corresponding to this one is added but "IsDataLengthSame" would capture this issue too.

This PR should solve (most of) this:
https://github.com/AllenNeuralDynamics/aind-fip-qc-raw/issues/7